### PR TITLE
Remove create user on /config

### DIFF
--- a/library.js
+++ b/library.js
@@ -305,7 +305,7 @@ plugin.findOrCreateUser = async (token, userData, req) => {
 
   /* create the user from payload if necessary */
   winston.debug('createUser?', !userId);
-  if (!userId && (req.method === 'POST' || req.path === '/api/config')) {
+  if (!userId && req.method === 'POST') {
     if (plugin.settings.noRegistration === 'on') {
       throw new Error('no-match');
     }


### PR DESCRIPTION
Det blir nå opprettet brukere for tidlig. Kan være vi kunne fikset det med å ikke kalle /config på like mange kall, men tror uansett vi får et problem med notifikasjoner. Altså at det vil kalles på /config før vi skal lage brukere på alle som har arena. 

Husker du om det var noen annen grunn enn å gjøre første post raskere vi tillot createUser på /config @jnatten ?