### PR TITLE
Update logic to update errors in user data

### DIFF
--- a/library.js
+++ b/library.js
@@ -309,10 +309,8 @@ plugin.updateUserProfile = async (uid, userData, isNewUser) => {
   }, {});
   try {
     for (const key in obj) {
-      if (profileFields.includes(key)) {
-        if (Object.prototype.hasOwnProperty.call(obj, key)) {
-          await db.setObjectField('user:' + uid, key, obj[key]);
-        }
+      if (Object.prototype.hasOwnProperty.call(obj, key)) {
+        await db.setObjectField('user:' + uid, key, obj[key]);
       }
     }
   } catch (error) {

--- a/library.js
+++ b/library.js
@@ -307,12 +307,22 @@ plugin.updateUserProfile = async (uid, userData, isNewUser) => {
     }
     return result;
   }, {});
-  for (const key in obj) {
-    if (profileFields.includes(key)) {
-      if (Object.prototype.hasOwnProperty.call(obj, key)) {
-        await db.setObjectField('user:' + uid, key, obj[key]);
+  try {
+    for (const key in obj) {
+      if (profileFields.includes(key)) {
+        if (Object.prototype.hasOwnProperty.call(obj, key)) {
+          await db.setObjectField('user:' + uid, key, obj[key]);
+        }
       }
     }
+  } catch (error) {
+    winston.warn(
+      '[feide-authentication] Unable to update profile information for uid: ' +
+        uid +
+        '(' +
+        error.message +
+        ')',
+    );
   }
 };
 


### PR DESCRIPTION
Simplifiserer hvordan vi gjør brukeroppdateringer hvis det er mismatch med objektet vi sender inn fra feide. Det gamle opplegget ville ikke fungert på grunn av at de oppdaterer eposten gjennom epost-valideringslogikken deres. Alternativ er å kjøre updateUser fortsatt og bare sette epost ved siden av. Tenkte det er bedre å bare oppdatere alle felter i samme logikk. Vi må bare passe på at vi ikke gjør noe endringer på noe av brukerobjektene etter vi kjører normalisering av brukerobjektet, da vil vi få mismatch. 